### PR TITLE
Front-end contact form validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.7.0 / 2017 Dec 22
+
+> This release adds front-end form validation for the contact form. We require
+> both the subject and body and show error feedback when either isn't filled in.
+
+* **Add** - added front-end contact from validation
+
+```clojure
+[ilyab "0.7.0"]
+```
+
 ## v0.6.0 / 2017 Dec 19
 
 > This release changes the "send" button to "sending..." on the contact form while

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ilyab "0.6.0"
+(defproject ilyab "0.7.0"
 
   :description "Ilya's home on the web"
   :url "http://ilyab.com"

--- a/src/cljs/ilyab/core.cljs
+++ b/src/cljs/ilyab/core.cljs
@@ -104,8 +104,7 @@
           :value @subj
           :on-change #(rf/dispatch [:subj-change (-> % .-target .-value)])
           :required true}]
-        [:div.invalid-feedback
-         "C'mon, no subject for me?"]]
+        [:div.invalid-feedback "C'mon, no subject for me?"]]
        [:div.form-group
         [:label {:for "message"} "Message"]
         [:textarea#message.form-control
@@ -115,8 +114,7 @@
           :value @msg
           :on-change #(rf/dispatch [:msg-change (-> % .-target .-value)])
           :required true}]
-        [:div.invalid-feedback
-         "Cat got your tongue? :-)"]]
+        [:div.invalid-feedback "Cat got your tongue? :-)"]]
        [:button.btn.btn-primary
         {:type "button"
          :on-click #(rf/dispatch [:contact-submit])

--- a/src/cljs/ilyab/core.cljs
+++ b/src/cljs/ilyab/core.cljs
@@ -94,7 +94,7 @@
         subj (rf/subscribe [:subject])
         msg (rf/subscribe [:message])]
     (if (or (= :open status) (= :sending status))
-      [:form#contact-form.contact-form {:class (if (:validated @c) "was-validated"), :noValidate true}
+      [:form.contact-form {:class (if (:validated @c) "was-validated"), :noValidate true}
        [:div.form-group
         [:label {:for "subject"} "Subject"]
         [:input#subject.form-control

--- a/src/cljs/ilyab/core.cljs
+++ b/src/cljs/ilyab/core.cljs
@@ -94,7 +94,7 @@
         subj (rf/subscribe [:subject])
         msg (rf/subscribe [:message])]
     (if (or (= :open status) (= :sending status))
-      [:form.contact-form {:action "/v1/contact", :method "post"}
+      [:form#contact-form.contact-form {:class (if (:validated @c) "was-validated"), :noValidate true}
        [:div.form-group
         [:label {:for "subject"} "Subject"]
         [:input#subject.form-control
@@ -102,7 +102,10 @@
           :name "subject"
           :placeholder "Subject"
           :value @subj
-          :on-change #(rf/dispatch [:subj-change (-> % .-target .-value)])}]]
+          :on-change #(rf/dispatch [:subj-change (-> % .-target .-value)])
+          :required true}]
+        [:div.invalid-feedback
+         "C'mon, no subject for me?"]]
        [:div.form-group
         [:label {:for "message"} "Message"]
         [:textarea#message.form-control
@@ -110,7 +113,10 @@
           :name "message"
           :placeholder "Message"
           :value @msg
-          :on-change #(rf/dispatch [:msg-change (-> % .-target .-value)])}]]
+          :on-change #(rf/dispatch [:msg-change (-> % .-target .-value)])
+          :required true}]
+        [:div.invalid-feedback
+         "Cat got your tongue? :-)"]]
        [:button.btn.btn-primary
         {:type "button"
          :on-click #(rf/dispatch [:contact-submit])

--- a/src/cljs/ilyab/events.cljs
+++ b/src/cljs/ilyab/events.cljs
@@ -28,7 +28,7 @@
   :contact-submit
   (fn [db [_ _]] ;; TODO what are these two args _ _?
     (.log js/console (:subject db) (:message db))
-    (if (and (:subject db) (:message db))
+    (if (every? not-empty [(:subject db) (:message db)])
       (do (POST "/v1/contact"
             {:params (select-keys db [:subject :message])
              :handler #(dispatch [:contact-success %1])

--- a/src/cljs/ilyab/events.cljs
+++ b/src/cljs/ilyab/events.cljs
@@ -28,18 +28,22 @@
   :contact-submit
   (fn [db [_ _]] ;; TODO what are these two args _ _?
     (.log js/console (:subject db) (:message db))
-    (POST "/v1/contact"
-      {:params (select-keys db [:subject :message])
-       :handler #(dispatch [:contact-success %1])
-       :error-handler #(dispatch [:contact-error %1])})
-    (assoc-in db [:contact :status] :sending)))
+    (if (and (:subject db) (:message db))
+      (do (POST "/v1/contact"
+            {:params (select-keys db [:subject :message])
+             :handler #(dispatch [:contact-success %1])
+             :error-handler #(dispatch [:contact-error %1])})
+          (assoc-in db [:contact :status] :sending))
+      (assoc-in db [:contact :validated] true))))
 
 ;; Handles successful responses from submitting the contact form
 (reg-event-db
   :contact-success
   (fn [db [_ resp]]
     (.log js/console (str "contact-success: " resp))
-    (update db :contact #(assoc % :status :sent :msg "Message sent. Thanks! :-)"))))
+    (update db :contact #(assoc % :status :sent
+                                  :msg "Message sent. Thanks! :-)"
+                                  :validated false))))
 
 ;; Handles successful error responses from submitting the contact form
 (reg-event-db


### PR DESCRIPTION
We're now validating that the subject and message have been entered on
the contact form before submitting to the back-end. Also added snazzy
error feedback messages.